### PR TITLE
feat: Change stdout & stderr handing to manual Read

### DIFF
--- a/Hexus.Daemon/Contracts/LogType.cs
+++ b/Hexus.Daemon/Contracts/LogType.cs
@@ -1,54 +1,8 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
 namespace Hexus.Daemon.Contracts;
 
-[JsonConverter(typeof(LogTypeJsonConverter))]
-public sealed class LogType
+public enum LogType
 {
-    public static readonly LogType System = new("SYSTEM");
-    public static readonly LogType StdOut = new("STDOUT");
-    public static readonly LogType StdErr = new("STDERR");
-
-    public readonly string Name;
-
-    private LogType(string name)
-    {
-        Name = name;
-    }
-
-    public override string ToString() => Name;
-
-    public static bool TryParse(ReadOnlySpan<char> span, [MaybeNullWhen(false)] out LogType result)
-    {
-        result = span switch
-        {
-            "SYSTEM" => System,
-            "STDOUT" => StdOut,
-            "STDERR" => StdErr,
-            _ => null,
-        };
-
-        return result is not null;
-    }
-
-    internal class LogTypeJsonConverter : JsonConverter<LogType>
-    {
-        public override LogType? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            var logTypeString = reader.GetString();
-
-            if (logTypeString is null) return null;
-
-            return TryParse(logTypeString, out var logType)
-                ? logType
-                : null;
-        }
-
-        public override void Write(Utf8JsonWriter writer, LogType value, JsonSerializerOptions options)
-        {
-            writer.WriteStringValue(value.Name);
-        }
-    }
+    STDOUT,
+    STDERR,
+    SYSTEM,
 }

--- a/Hexus.Daemon/Services/ProcessManagerService.cs
+++ b/Hexus.Daemon/Services/ProcessManagerService.cs
@@ -5,7 +5,6 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Hexus.Daemon.Services;
 

--- a/Hexus.Daemon/Services/ProcessManagerService.cs
+++ b/Hexus.Daemon/Services/ProcessManagerService.cs
@@ -176,8 +176,6 @@ internal partial class ProcessManagerService(
 
     #endregion
 
-    #region Log process events handlers
-
     private async Task HandleLogs(HexusApplication application, Process process, LogType logType)
     {
         var streamReader = logType switch
@@ -195,8 +193,6 @@ internal partial class ProcessManagerService(
             processLogsService.ProcessApplicationLog(application, logType, str);
         }
     }
-
-    #endregion
 
     #region Exit process event handlers
 

--- a/Hexus.Daemon/Services/ProcessManagerService.cs
+++ b/Hexus.Daemon/Services/ProcessManagerService.cs
@@ -194,7 +194,7 @@ internal partial class ProcessManagerService(
 
             if (bytesRead == 0) continue;
 
-            processLogsService.ProcessApplicationLog(application, logType, memoryOwner.Memory[..bytesRead]);
+            await processLogsService.ProcessApplicationLog(application, logType, memoryOwner.Memory[..bytesRead]);
         }
     }
 

--- a/Hexus/Commands/Applications/LogsCommand.cs
+++ b/Hexus/Commands/Applications/LogsCommand.cs
@@ -100,7 +100,7 @@ internal static class LogsCommand
 
     private static void PrintLogLine(ApplicationLog log, TimeZoneInfo timeZoneInfo, bool showDates)
     {
-        var color = GetLogTypeColor(log.LogType.Name);
+        var color = GetLogTypeColor(log.LogType);
 
         var timezone = TimeZoneInfo.ConvertTime(log.Date, timeZoneInfo);
         var date = showDates ? $"{timezone:yyyy-MM-dd HH:mm:ss} [{color}]| " : $"[{color}]";
@@ -109,11 +109,11 @@ internal static class LogsCommand
         PrettyConsole.OutLimitlessWidth.MarkupLine($"{date}{log.LogType} |[/] {text}");
     }
 
-    private static Color GetLogTypeColor(ReadOnlySpan<char> logType) => logType switch
+    private static Color GetLogTypeColor(LogType logType) => logType switch
     {
-        "STDOUT" => Color.SpringGreen3,
-        "STDERR" => Color.Red3_1,
-        "SYSTEM" => Color.MediumPurple2,
+        LogType.STDOUT => Color.SpringGreen3,
+        LogType.STDERR => Color.Red3_1,
+        LogType.SYSTEM => Color.MediumPurple2,
         _ => throw new ArgumentOutOfRangeException(nameof(logType), "The requested log type is not mapped to a color"),
     };
 }


### PR DESCRIPTION
~~Change the code to instead of relying of .NET `OutputDataReceived` which is invocated on every line, use  the raw `ReadAsync` method of the StreamReader(s).~~

~~This allows for a more complete log, including non-complete lines, such as shell prompts~~

While the code now runs the ReadLineAsync function manually, we still handle the logs line-per-line bc  handling all the edge cases for proprierly work with ReadAsync was getting out of hand