### PR TITLE
feat: Interactive logs command

### DIFF
--- a/Hexus.Daemon/Configuration/EnvironmentHelper.cs
+++ b/Hexus.Daemon/Configuration/EnvironmentHelper.cs
@@ -5,7 +5,7 @@ public static class EnvironmentHelper
     public static readonly bool IsDevelopment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") == "Development";
     public static readonly string Home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
-    // XDG directories based on the XDG basedir spec, we use there folder on Windows too.
+    // XDG directories based on the XDG basedir spec, we use these folders on Windows too.
     //
     // XDG_RUNTIME_DIR does not have a default we can point to due to the requirement this folder has (being owned by the user and being the only with Read Write Execute so 0o700)
     // This mean that we need to default to a directory in the temp, on Windows we instead use the XDG_STATE_HOME
@@ -17,11 +17,11 @@ public static class EnvironmentHelper
     private static readonly string HexusStateDirectory = $"{XdgState}/hexus";
     private static readonly string HexusRuntimeDirectory = XdgRuntime ?? CreateRuntimeDirectory();
 
-    public static readonly string LogFile = NormalizePath(IsDevelopment ? $"{HexusStateDirectory}/daemon.dev.log" : $"{HexusStateDirectory}/daemon.log");
-    public static readonly string ApplicationLogsDirectory = NormalizePath($"{HexusStateDirectory}/applications");
+    public static readonly string LogFile = Path.GetFullPath(IsDevelopment ? $"{HexusStateDirectory}/daemon.dev.log" : $"{HexusStateDirectory}/daemon.log");
+    public static readonly string ApplicationLogsDirectory = Path.GetFullPath($"{HexusStateDirectory}/applications");
 
-    public static readonly string ConfigurationFile = NormalizePath(IsDevelopment ? $"{XdgConfig}/hexus.dev.yaml" : $"{XdgConfig}/hexus.yaml");
-    public static readonly string SocketFile = NormalizePath(IsDevelopment ? $"{HexusRuntimeDirectory}/hexus.dev.sock" : $"{HexusRuntimeDirectory}/hexus.sock");
+    public static readonly string ConfigurationFile = Path.GetFullPath(IsDevelopment ? $"{XdgConfig}/hexus.dev.yaml" : $"{XdgConfig}/hexus.yaml");
+    public static readonly string SocketFile = Path.GetFullPath(IsDevelopment ? $"{HexusRuntimeDirectory}/hexus.dev.sock" : $"{HexusRuntimeDirectory}/hexus.sock");
 
     public static void EnsureDirectoriesExistence()
     {
@@ -29,7 +29,7 @@ public static class EnvironmentHelper
         // The check is performed on the env itself to prevent erroring if we are falling back to something else (the XDG_STATE_HOME on Windows and /tmp/hexus-runtime on Linux)
         if (XdgRuntime is not null && !Directory.Exists(XdgRuntime))
         {
-            throw new InvalidOperationException("The directory XDG_RUNTIME_DIR does not exist.");
+            throw new InvalidOperationException("The directory $XDG_RUNTIME_DIR does not exist.");
         }
 
         Directory.CreateDirectory(XdgConfig);
@@ -37,9 +37,6 @@ public static class EnvironmentHelper
         Directory.CreateDirectory(HexusRuntimeDirectory);
         Directory.CreateDirectory(ApplicationLogsDirectory);
     }
-
-    // Used to convert to the correct slashes ("/" and "\") based on the platform
-    public static string NormalizePath(string path) => Path.GetFullPath(path);
 
     private static string CreateRuntimeDirectory()
     {

--- a/Hexus.Daemon/Contracts/ApplicationLog.cs
+++ b/Hexus.Daemon/Contracts/ApplicationLog.cs
@@ -1,12 +1,3 @@
 namespace Hexus.Daemon.Contracts;
 
-public record ApplicationLog(DateTimeOffset Date, LogType LogType, string Text)
-{
-    public bool IsLogDateInRange(DateTimeOffset? before = null, DateTimeOffset? after = null)
-    {
-        if (before is { } b && Date > b) return false;
-        if (after is { } a && Date < a) return false;
-
-        return true;
-    }
-}
+public record ApplicationLog(DateTimeOffset Date, LogType LogType, string Text);

--- a/Hexus.Daemon/Endpoints/Applications/EditApplicationEndpoint.cs
+++ b/Hexus.Daemon/Endpoints/Applications/EditApplicationEndpoint.cs
@@ -33,10 +33,10 @@ internal sealed class EditApplicationEndpoint : IEndpoint
         // FIlle the rest of the request with the data from the application to edit
         request = new EditApplicationRequest(
             Name: request.Name ?? application.Name,
-            Executable: EnvironmentHelper.NormalizePath(request.Executable ?? application.Executable),
+            Executable: Path.GetFullPath(request.Executable ?? application.Executable),
             Arguments: request.Arguments ?? application.Arguments,
             Note: request.Note ?? application.Note ?? "",
-            WorkingDirectory: EnvironmentHelper.NormalizePath(request.WorkingDirectory ?? application.WorkingDirectory),
+            WorkingDirectory: Path.GetFullPath(request.WorkingDirectory ?? application.WorkingDirectory),
             NewEnvironmentVariables: request.NewEnvironmentVariables ?? [],
             RemoveEnvironmentVariables: request.RemoveEnvironmentVariables ?? [],
             IsReloadingEnvironmentVariables: request.IsReloadingEnvironmentVariables ?? false

--- a/Hexus.Daemon/Endpoints/Applications/GetLogsEndpoint.cs
+++ b/Hexus.Daemon/Endpoints/Applications/GetLogsEndpoint.cs
@@ -1,21 +1,24 @@
 using EndpointMapper;
 using Hexus.Daemon.Configuration;
-using Hexus.Daemon.Contracts;
 using Hexus.Daemon.Services;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using System.Net;
+using System.Text.Json;
 
 namespace Hexus.Daemon.Endpoints.Applications;
 
 internal sealed class GetLogsEndpoint : IEndpoint
 {
     [HttpMap(HttpMapMethod.Get, "/{name}/logs")]
-    public static Results<Ok<IAsyncEnumerable<ApplicationLog>>, NotFound> Handle(
+    public static async Task<NotFound?> Handle(
         [FromServices] HexusConfiguration configuration,
         [FromServices] ProcessLogsService processLogsService,
+        HttpContext context,
+        [FromServices] IOptions<JsonOptions> jsonOptions,
         [FromRoute] string name,
         [FromQuery] DateTimeOffset? before = null,
-        [FromQuery] DateTimeOffset? after = null,
         CancellationToken ct = default)
     {
         if (!configuration.Applications.TryGetValue(name, out var application))
@@ -24,8 +27,26 @@ internal sealed class GetLogsEndpoint : IEndpoint
         // When the aspnet or the hexus cancellation token get cancelled it cancels this as well
         var combinedCtSource = CancellationTokenSource.CreateLinkedTokenSource(ct, HexusLifecycle.DaemonStoppingToken);
 
-        var logs = processLogsService.GetLogs(application, before, after, combinedCtSource.Token);
+        var logs = processLogsService.GetLogs(application, before, combinedCtSource.Token);
 
-        return TypedResults.Ok(logs);
+        context.Response.StatusCode = (int)HttpStatusCode.OK;
+        context.Response.Headers.ContentType = "application/json; charset=utf-8";
+
+        // We need to manually write the response body as ASP.NET won't send the header using TypedResults.Ok() or anything similar
+
+        await context.Response.WriteAsync("[", ct);
+        await context.Response.Body.FlushAsync(ct);
+
+        await foreach (var item in logs)
+        {
+            await context.Response.WriteAsync(JsonSerializer.Serialize(item, jsonOptions.Value.JsonSerializerOptions), cancellationToken: ct);
+            await context.Response.WriteAsync(",", ct);
+            await context.Response.Body.FlushAsync(ct);
+        }
+
+        await context.Response.WriteAsync("]", ct);
+        await context.Response.Body.FlushAsync(ct);
+
+        return null;
     }
 }

--- a/Hexus.Daemon/Extensions/MapperExtensions.cs
+++ b/Hexus.Daemon/Extensions/MapperExtensions.cs
@@ -12,9 +12,9 @@ internal static class MapperExtensions
         return new()
         {
             Name = request.Name,
-            Executable = EnvironmentHelper.NormalizePath(request.Executable),
+            Executable = Path.GetFullPath(request.Executable),
             Arguments = request.Arguments,
-            WorkingDirectory = EnvironmentHelper.NormalizePath(request.WorkingDirectory ?? EnvironmentHelper.Home),
+            WorkingDirectory = Path.GetFullPath(request.WorkingDirectory ?? EnvironmentHelper.Home),
             Note = request.Note,
             EnvironmentVariables = request.EnvironmentVariables ?? [],
         };
@@ -24,9 +24,9 @@ internal static class MapperExtensions
     {
         return new(
             Name: application.Name,
-            Executable: EnvironmentHelper.NormalizePath(application.Executable),
+            Executable: Path.GetFullPath(application.Executable),
             Arguments: application.Arguments,
-            WorkingDirectory: EnvironmentHelper.NormalizePath(application.WorkingDirectory),
+            WorkingDirectory: Path.GetFullPath(application.WorkingDirectory),
             Note: application.Note,
             EnvironmentVariables: application.EnvironmentVariables,
             Status: application.Status,

--- a/Hexus.Daemon/Extensions/ProcessExtensions.cs
+++ b/Hexus.Daemon/Extensions/ProcessExtensions.cs
@@ -9,19 +9,15 @@ internal static class ProcessExtensions
     public static double GetProcessCpuUsage(this Process process, ProcessStatisticsService.CpuStatistics cpuStatistics)
     {
         var currentTime = DateTimeOffset.UtcNow;
-        var timeDifference = currentTime - cpuStatistics.LastGetProcessCpuUsageInvocation;
+        var deltaTime = currentTime - cpuStatistics.LastTime;
 
-        // In a situation like this we are provably going to give an unreasonable number, it's better to just say 0% than 100%
-        if (timeDifference < TimeSpan.FromMilliseconds(100))
-            return 0.00;
+        var totalProcessTime = process.TotalProcessorTime;
+        var deltaProcessTime = totalProcessTime - cpuStatistics.LastTotalProcessorTime;
 
-        var currentTotalProcessorTime = process.TotalProcessorTime;
-        var processorTimeDifference = currentTotalProcessorTime - cpuStatistics.LastTotalProcessorTime;
+        var cpuUsage = deltaProcessTime / Environment.ProcessorCount / deltaTime;
 
-        var cpuUsage = processorTimeDifference / Environment.ProcessorCount / timeDifference;
-
-        cpuStatistics.LastTotalProcessorTime = currentTotalProcessorTime;
-        cpuStatistics.LastGetProcessCpuUsageInvocation = currentTime;
+        cpuStatistics.LastTotalProcessorTime = totalProcessTime;
+        cpuStatistics.LastTime = currentTime;
 
         return cpuUsage * 100;
     }

--- a/Hexus.Daemon/Services/ProcessLogsService.cs
+++ b/Hexus.Daemon/Services/ProcessLogsService.cs
@@ -48,7 +48,7 @@ internal partial class ProcessLogsService(ILogger<ProcessLogsService> logger)
         {
             await foreach (var log in channel.Reader.ReadAllAsync(ct))
             {
-                if (before.HasValue && log.Date > before) yield break;
+                if (before.HasValue && log.Date > before.Value) yield break;
 
                 yield return log;
             }

--- a/Hexus.Daemon/Services/ProcessStatisticsService.cs
+++ b/Hexus.Daemon/Services/ProcessStatisticsService.cs
@@ -111,7 +111,7 @@ internal sealed class ProcessStatisticsService(ProcessManagerService processMana
             var stats = statistics.ProcessCpuStatistics.GetOrCreate(process.Id, _ => new CpuStatistics
             {
                 LastTotalProcessorTime = TimeSpan.Zero,
-                LastGetProcessCpuUsageInvocation = DateTimeOffset.UtcNow,
+                LastTime = DateTimeOffset.UtcNow,
             });
 
             yield return process.GetProcessCpuUsage(stats);
@@ -147,7 +147,7 @@ internal sealed class ProcessStatisticsService(ProcessManagerService processMana
     internal record CpuStatistics
     {
         public TimeSpan LastTotalProcessorTime { get; set; }
-        public DateTimeOffset LastGetProcessCpuUsageInvocation { get; set; }
+        public DateTimeOffset LastTime { get; set; }
     }
 }
 

--- a/Hexus/Commands/Applications/EditCommand.cs
+++ b/Hexus/Commands/Applications/EditCommand.cs
@@ -85,11 +85,11 @@ internal static class EditCommand
         }
 
         if (newWorkingDirectory is not null)
-            newWorkingDirectory = EnvironmentHelper.NormalizePath(newWorkingDirectory);
+            newWorkingDirectory = Path.GetFullPath(newWorkingDirectory);
 
         if (newExecutable is not null)
             newExecutable = Path.IsPathFullyQualified(newExecutable)
-                ? EnvironmentHelper.NormalizePath(newExecutable)
+                ? Path.GetFullPath(newExecutable)
                 : PathHelper.ResolveExecutable(newExecutable);
 
         if (reloadEnv)

--- a/Hexus/Commands/Applications/LogsCommand.cs
+++ b/Hexus/Commands/Applications/LogsCommand.cs
@@ -456,7 +456,6 @@ internal static partial class LogsCommand
 
         var logText = PaginateString(line.Log.Text, offset, offset == 0 ? startLen : width, out var hadMore);
 
-        // If the length of the paginated is different then it means it had to truncate
         var seeMoreArrow = hadMore ? "[black on white]>[/]" : ""; 
 
         // When the offset is not 0 do not show the header

--- a/Hexus/Commands/Applications/LogsCommand.cs
+++ b/Hexus/Commands/Applications/LogsCommand.cs
@@ -564,7 +564,7 @@ internal static partial class LogsCommand
         // If we have more then stringLen chars we need to be carful as we don't want to consider ANSI chars to part of this
         else
         {
-            // We re-define the streamingEnumerator because now we have a startIndex
+            // We re-define the enumerator because now we have a startIndex
             ansiSequences = AnsiRegex().EnumerateMatches(text, startIndex);
             var found = ansiSequences.MoveNext();
             var takenChars = 0;

--- a/Hexus/Commands/Applications/LogsCommand.cs
+++ b/Hexus/Commands/Applications/LogsCommand.cs
@@ -216,6 +216,9 @@ internal static class LogsCommand
                     case ConsoleKey.R when key.Modifiers == ConsoleModifiers.Control:
                         ReprintScreen(lines, logs, timezone, dates);
                         break;
+
+                    // Up & Down
+
                     case ConsoleKey.UpArrow:
                     case ConsoleKey.K:
                         {
@@ -268,6 +271,9 @@ internal static class LogsCommand
 
                             break;
                         }
+
+                    // Page keys
+
                     case ConsoleKey.PageUp:
                         {
                             var line = logs.First();
@@ -325,6 +331,29 @@ internal static class LogsCommand
                                 PrettyConsole.Out.Write($"{fetchedLog.FileOffset} | ");
                                 PrintLogLine(fetchedLog.Log, timezone, dates);
                             }
+
+                            break;
+                        }
+
+                    // "g" & "G"
+
+                    case ConsoleKey.G when key.Modifiers == ConsoleModifiers.Shift:
+                        {
+                            offset = file.Length;
+                            lines = Console.WindowHeight - 1;
+                            logs = await GetLogsFromFileBackwardsAsync(file, lines, offset, current, before, after, ct).Reverse().ToListAsync(ct);
+
+                            ReprintScreen(lines, logs, timezone, dates);
+
+                            break;
+                        }
+                    case ConsoleKey.G:
+                        {
+                            offset = 0;
+                            lines = Console.WindowHeight - 1;
+                            logs = await GetLogsFromFileForwardsAsync(file, lines, offset, before, ct).ToListAsync(ct);
+
+                            ReprintScreen(lines, logs, timezone, dates);
 
                             break;
                         }

--- a/Hexus/Commands/Applications/NewCommand.cs
+++ b/Hexus/Commands/Applications/NewCommand.cs
@@ -73,7 +73,7 @@ internal static class NewCommand
         }
 
         workingDirectory ??= Environment.CurrentDirectory;
-        workingDirectory = EnvironmentHelper.NormalizePath(workingDirectory);
+        workingDirectory = Path.GetFullPath(workingDirectory);
 
         if (useShellEnv)
         {
@@ -93,7 +93,7 @@ internal static class NewCommand
         }
 
         executable = Path.IsPathFullyQualified(executable)
-            ? EnvironmentHelper.NormalizePath(executable)
+            ? Path.GetFullPath(executable)
             : PathHelper.ResolveExecutable(executable);
 
         // Python will not send the logs due to buffering the stdout/stderr, since this can look like a bug in Hexus we warn the user

--- a/Hexus/Commands/Utils/MigratePm2Command.cs
+++ b/Hexus/Commands/Utils/MigratePm2Command.cs
@@ -60,7 +60,7 @@ internal static class MigratePm2Command
 
     static MigratePm2Command()
     {
-        Pm2DumpFile.SetDefaultValue(EnvironmentHelper.NormalizePath($"{EnvironmentHelper.Home}/.pm2/dump.pm2"));
+        Pm2DumpFile.SetDefaultValue(Path.GetFullPath($"{EnvironmentHelper.Home}/.pm2/dump.pm2"));
 
         Command.SetHandler(Handler);
     }

--- a/Hexus/Hexus.csproj
+++ b/Hexus/Hexus.csproj
@@ -4,6 +4,8 @@
         <OutputType>Exe</OutputType>
 
         <AssemblyName>hexus</AssemblyName>
+
+        <LangVersion>preview</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(SelfContained)' == 'true'">

--- a/Hexus/PathHelper.cs
+++ b/Hexus/PathHelper.cs
@@ -1,12 +1,11 @@
-﻿using Hexus.Daemon.Configuration;
+﻿namespace Hexus;
 
-namespace Hexus;
 internal static class PathHelper
 {
     public static string ResolveExecutable(string executable)
     {
         // relative folders resolver (./../exe)
-        var absolutePath = EnvironmentHelper.NormalizePath(executable);
+        var absolutePath = Path.GetFullPath(executable);
 
         if (File.Exists(absolutePath))
             return absolutePath;
@@ -31,7 +30,7 @@ internal static class PathHelper
                 return [file];
             })
             .Where(File.Exists)
-            .Select(EnvironmentHelper.NormalizePath)
+            .Select(Path.GetFullPath)
             .FirstOrDefault();
 
         if (resolvedExecutable is not null)

--- a/Hexus/Program.cs
+++ b/Hexus/Program.cs
@@ -33,7 +33,7 @@ var rootCommand = new RootCommand("The Hexus management CLI")
 var builder = new CommandLineBuilder(rootCommand);
 
 builder.UseDefaults();
-builder.UseExceptionHandler((exception, _) => PrettyConsole.Error.WriteException(exception), 1);
+builder.UseExceptionHandler((exception, _) => PrettyConsole.Error.WriteException(exception, ExceptionFormats.ShortenPaths), 1);
 
 var app = builder.Build();
 

--- a/Hexus/Program.cs
+++ b/Hexus/Program.cs
@@ -37,7 +37,4 @@ builder.UseExceptionHandler((exception, _) => PrettyConsole.Error.WriteException
 
 var app = builder.Build();
 
-// TODO(commit): Remove this test code
-args = ["logs", "cmd", "--no-streaming"];
- 
 return await app.InvokeAsync(args);

--- a/Hexus/Program.cs
+++ b/Hexus/Program.cs
@@ -37,4 +37,7 @@ builder.UseExceptionHandler((exception, _) => PrettyConsole.Error.WriteException
 
 var app = builder.Build();
 
+// TODO(commit): Remove this test code
+args = ["logs", "cmd", "--no-streaming"];
+ 
 return await app.InvokeAsync(args);

--- a/README.md
+++ b/README.md
@@ -85,12 +85,11 @@ hexus logs <application name>
 
 ##### Flags
 
-- `--lines` or `-l` to select a number of lines to fetch from the log file
 - `--no-streaming` to disable the streaming of logs to the console while the command is active
 - `--no-dates` to disable the Hexus provided timestamp of the log lines
 - `--current` or `-c` to show only the logs from the currently running for last execution of the application.
-- `--after` or `-a` to select logs that have a timestamp after the one provided (does not get affected by `--timezone`)
-- `--before` or `-b` to select logs that have a timestamp before the one provided (does not get affected by `--timezone`)
+- `--after` or `-a` to select logs that have a timestamp after the one provided (does get affected by `--timezone`)
+- `--before` or `-b` to select logs that have a timestamp before the one provided (does get affected by `--timezone`)
 - `--timezone` timezone of the Hexus provided timestamps, should be picked from the system-provided timezones. Defaults to the computer current timezone.
 
 All the flags are available in the help for the command, you can use the `--help` or `-h` flag to see it.
@@ -100,7 +99,7 @@ All the flags are available in the help for the command, you can use the `--help
 If you want to manually parse the log files the format is as follows: `[<date>,<type>] <message>` where
 
 - `date` is a date in UTC time using the ISO8601 format
-- `type` is one of `STDOUT`, `STDERR` or `SYSTEM`, with `SYSTEM` being used for Hexus messages like the application start or stop while `STDOUT` and `STDERR`for the actual logs of the application
+- `type` is one of `STDOUT`, `STDERR` or `SYSTEM`, with `SYSTEM` being used for Hexus messages like the application start or stop while `STDOUT` and `STDERR` for the actual logs of the application
 - `message` is the actual message the application logged to the console
 
 #### Start / Stop / Restart / Delete application


### PR DESCRIPTION
The logs command will behave **similar** to the `less` command. It doesn't actually use less, but Hexus will replicate the behavior of the part that we care about.

The streaming of logs will still be supported, but they will be displayed only when the file is scrolled to the bottom, else the streamed data will be ignored and them read (if necessary) from disk